### PR TITLE
Avoid whitespaces between social link icons

### DIFF
--- a/src/partials/social.html
+++ b/src/partials/social.html
@@ -22,20 +22,20 @@
 
 <!-- Social links -->
 <div class="md-social">
-  {% for social in config.extra.social %}
+  {%- for social in config.extra.social -%}
 
     <!-- Automatically set rel=me for Mastodon -->
-    {% set rel = "noopener" %}
-    {% if "mastodon" in social.icon %}
-      {% set rel = rel ~ " me" %}
-    {% endif %}
+    {%- set rel = "noopener" -%}
+    {%- if "mastodon" in social.icon -%}
+      {%- set rel = rel ~ " me" -%}
+    {%- endif -%}
 
     <!-- Compute title and render link -->
-    {% set title = social.name %}
-    {% if not title and "//" in social.link %}
-      {% set _, url = social.link.split("//") %}
-      {% set title  = url.split("/")[0] %}
-    {% endif %}
+    {%- set title = social.name -%}
+    {%- if not title and "//" in social.link -%}
+      {%- set _, url = social.link.split("//") -%}
+      {%- set title  = url.split("/")[0] -%}
+    {%- endif -%}
     <a
       href="{{ social.link }}"
       target="_blank" rel="{{ rel }}"
@@ -44,5 +44,5 @@
     >
       {% include ".icons/" ~ social.icon ~ ".svg" %}
     </a>
-  {% endfor %}
+  {%- endfor -%}
 </div>


### PR DESCRIPTION
I've adapted the Jinja syntax related to generating social links in the footer to strip whitespaces around the `<a>` tags to avoid whitespaces between these tags as they are interpreted as actual whitespaces by the browser and, thus, add some implicit yet irrelevant spaces between the social link icons.

See this screenshot:

![image](https://github.com/sisp/mkdocs-material/assets/2206639/24e0fe88-bdb6-41a7-a07a-28809965e0a4)
